### PR TITLE
modified STARTING_BLOCK and INSERT_BATCH_SIZE

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,9 @@ PRIVATE_KEY=
 
 MERKLE_TREE_LEVELS=20
 # the block of the tornadoTrees contract deployment
-STARTING_BLOCK=0
-INSERT_BATCH_SIZE=60
+STARTING_BLOCK=11474714
+# the number of tornado cash deposits to process in each transaction, max appears to be 125
+INSERT_BATCH_SIZE=125
 # should not be more often than CONFIRMATION_BLOCKS time. e.g every 3 minutes
 CRON_EXPRESSION="0 */3 * * * *"
 CONFIRMATION_BLOCKS=3

--- a/.env.example
+++ b/.env.example
@@ -10,7 +10,7 @@ MERKLE_TREE_LEVELS=20
 # the block of the tornadoTrees contract deployment
 STARTING_BLOCK=11474714
 # the number of tornado cash deposits to process in each transaction, max appears to be 125
-INSERT_BATCH_SIZE=125
+INSERT_BATCH_SIZE=20
 # should not be more often than CONFIRMATION_BLOCKS time. e.g every 3 minutes
 CRON_EXPRESSION="0 */3 * * * *"
 CONFIRMATION_BLOCKS=3


### PR DESCRIPTION
After some trial and error I found that the script does not complete if STARTING_BLOCK is set to 0. I also experimented a bit to find that each tx can include about 125 deposits.